### PR TITLE
add javascript keywords

### DIFF
--- a/js.json
+++ b/js.json
@@ -3,7 +3,7 @@
   "match": "^(js|javascript)$",
   "kw0": ["break","case","continue","import","export","default","do","else",
     "for","goto","if","return","switch","typeof","while","undefined","null",
-    "eval","self","window","try","catch","throw","new"],
+    "eval","self","window","try","catch","throw","new","require"],
   "kw1":["Array","Boolean","Date","Error","EvalError","Function","Infinity",
     "JSON","Math","NaN","Number","Object","RangeError","ReferenceError",
     "RegExp","String","SyntaxError","TypeError","URIError","ArrayBuffer",
@@ -11,7 +11,7 @@
     "Int32Array","Int8Array","Intl","Map","Promise","Proxy","Reflect","Set",
     "Symbol","Uint16Array","Uint32Array","Uint8Array","Uint8ClampedArray",
     "WeakMap","WeakSet"],
-  "kw2":["function","var"],
+  "kw2":["function","var","const","let"],
   "rules": [
     ["area comment","^/\\*([^*]|\\*(?!/))*\\*/$"],
     ["area comment continue","^/\\*([^*]|\\*(?!/))*\\*?$"],


### PR DESCRIPTION
This PR adds `require`, `const` and `let` to the JavaScript keywords which are targetable.

Here's a screenshot example of `const` and `require` in action.

<img width="874" alt="screen shot 2017-07-28 at 14 15 48" src="https://user-images.githubusercontent.com/894092/28718778-546b6034-739f-11e7-9a75-8687033eb77d.png">
